### PR TITLE
Project | Update SDK Version to 2.9.0 and Update README

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,6 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:1.5.4"
     debugImplementation "androidx.compose.ui:ui-tooling:1.5.4"
 
-    implementation 'com.yuno.payments:android-sdk:2.8.1'
+    implementation 'com.yuno.payments:android-sdk:2.9.0'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }

--- a/app/src/main/java/com/yuno/payments/example/features/payment/activities/CheckoutCompleteActivity.kt
+++ b/app/src/main/java/com/yuno/payments/example/features/payment/activities/CheckoutCompleteActivity.kt
@@ -106,10 +106,15 @@ class CheckoutCompleteActivity : AppCompatActivity() {
         }
     }
 
-    private fun onPaymentStateChange(paymentState: String?, secondParam: String?) {
+    /**
+     * Callback that receives the payment state changes from Yuno SDK.
+     * @param paymentState The main payment state (SUCCEEDED, FAIL, PROCESSING, REJECT, INTERNAL_ERROR, CANCELED)
+     * @param paymentSubState Additional payment sub-state information providing more details about the payment status
+     */
+    private fun onPaymentStateChange(paymentState: String?, paymentSubState: String?) {
         paymentState?.let {
             restartView()
-            Log.e("Payment State", "State: $it, Second param: $secondParam")
+            Log.e("Payment State", "State: $it, Payment Sub-State: $paymentSubState")
         }
     }
 

--- a/app/src/main/java/com/yuno/payments/example/features/payment/activities/CheckoutLiteActivity.kt
+++ b/app/src/main/java/com/yuno/payments/example/features/payment/activities/CheckoutLiteActivity.kt
@@ -130,10 +130,15 @@ class CheckoutLiteActivity : AppCompatActivity() {
         }
     }
 
-    private fun onPaymentStateChange(paymentState: String?, secondParam: String?) {
+    /**
+     * Callback that receives the payment state changes from Yuno SDK.
+     * @param paymentState The main payment state (SUCCEEDED, FAIL, PROCESSING, REJECT, INTERNAL_ERROR, CANCELED)
+     * @param paymentSubState Additional payment sub-state information providing more details about the payment status
+     */
+    private fun onPaymentStateChange(paymentState: String?, paymentSubState: String?) {
         paymentState?.let {
             updateView(paymentState)
-            Log.d("CheckoutLite", "Payment state: $paymentState, Second param: $secondParam")
+            Log.d("CheckoutLite", "Payment State: $paymentState, Payment Sub-State: $paymentSubState")
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Upgrade to SDK 2.9.0**
> 
> - Bumps dependency to `com.yuno.payments:android-sdk:2.9.0`.
> 
> **Docs and API usage updates**
> 
> - Revamps `README.md` with clearer `YunoConfig` (adds `styles`), detailed Card Form Types, expanded `YunoLanguage` list, and a new Styles section (`YunoStyles`, `YunoButtonStyles`).
> - Documents `OneTimeTokenModel` and related models (`CardInformationModel`, `CustomerPayerInformationModel`, `Document`, `Phone`, `Address`).
> - Updates method signatures and docs:
>   - `startCheckout` `callbackPaymentState` now provides `(paymentState, paymentSubState)`.
>   - `startPayment` adds `callBackTokenWithInformation` and uses `showStatusYuno`.
>   - `startPaymentLite` adds `callBackTokenWithInformation`; `PaymentSelected` now uses `vaultedToken` and `paymentMethodType`.
> - Removes legacy sections (e.g., custom card form flow, loader flow) from README.
> 
> **Sample app adjustments**
> 
> - Updates `CheckoutCompleteActivity` and `CheckoutLiteActivity` to handle `(paymentState, paymentSubState)` and adjust logs accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cca168e3ba7883f86a25486dfa7de6e8f5f63c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->