### PR TITLE
[IMPROVE] [CORECM-15406] - Add the render mode flows

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,12 @@
                     android:scheme="yuno" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.yuno.payments.example.features.enrollment.activities.EnrollmentRenderActivity"
+            android:exported="false" />
+        <activity
+            android:name="com.yuno.payments.example.features.payment.activities.PaymentRenderActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/yuno/payments/example/CustomApplication.kt
+++ b/app/src/main/java/com/yuno/payments/example/CustomApplication.kt
@@ -1,12 +1,20 @@
 package com.yuno.payments.example
 
 import android.app.Application
+import com.yuno.presentation.core.card.CardFormType
 import com.yuno.sdk.Yuno
 import com.yuno.sdk.YunoConfig
 
 class CustomApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        Yuno.initialize(this, "API_KEY", YunoConfig())
+        Yuno.initialize(
+            this, 
+            "YOUR_API_KEY",
+            YunoConfig(
+                cardFlow = CardFormType.ONE_STEP,
+                saveCardEnabled = false,
+            )
+        )
     }
 }

--- a/app/src/main/java/com/yuno/payments/example/features/enrollment/activities/EnrollmentRenderActivity.kt
+++ b/app/src/main/java/com/yuno/payments/example/features/enrollment/activities/EnrollmentRenderActivity.kt
@@ -1,0 +1,199 @@
+package com.yuno.payments.example.features.enrollment.activities
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.View
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.ProgressBar
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.yuno.payments.example.BuildConfig
+import com.yuno.payments.example.R
+import com.yuno.payments.example.ui.views.CustomEditText
+import com.yuno.sdk.enrollment.render.YunoEnrollmentFragmentController
+import com.yuno.sdk.enrollment.render.YunoEnrollmentRenderListener
+import com.yuno.sdk.enrollment.render.startEnrollmentRender
+
+class EnrollmentRenderActivity : AppCompatActivity(), YunoEnrollmentRenderListener {
+
+    private lateinit var fragmentController: YunoEnrollmentFragmentController
+
+    private lateinit var editTextCustomerSession: CustomEditText
+    private lateinit var editTextCountryCode: CustomEditText
+    private lateinit var buttonStartEnrollment: Button
+    private lateinit var buttonSubmit: Button
+    private lateinit var progressBar: ProgressBar
+    private lateinit var fragmentContainer: FrameLayout
+
+    private var needsSubmit = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_enrollment_render)
+
+        initViews()
+        initListeners()
+    }
+
+    private fun initViews() {
+        editTextCustomerSession = findViewById(R.id.editText_customer_session)
+        editTextCountryCode = findViewById(R.id.editText_country_code)
+        buttonStartEnrollment = findViewById(R.id.button_start_enrollment)
+        buttonSubmit = findViewById(R.id.button_submit)
+        progressBar = findViewById(R.id.progress_bar)
+        fragmentContainer = findViewById(R.id.enrollment_fragment_container)
+
+        // Pre-fill with test data
+        editTextCustomerSession.setText(BuildConfig.YUNO_TEST_CUSTOMER_SESSION)
+        editTextCountryCode.setText(BuildConfig.YUNO_TEST_COUNTRY_CODE)
+
+        // Hide submit button initially
+        buttonSubmit.visibility = View.GONE
+    }
+
+    private fun initListeners() {
+        buttonStartEnrollment.setOnClickListener {
+            if (editTextCustomerSession.isValid && editTextCountryCode.isValid) {
+                startEnrollmentRenderFlow()
+            }
+        }
+
+        buttonSubmit.setOnClickListener {
+            if (::fragmentController.isInitialized) {
+                fragmentController.submitForm()
+            }
+        }
+    }
+
+    private fun startEnrollmentRenderFlow() {
+        // Hide start button and show container
+        buttonStartEnrollment.isEnabled = false
+
+        fragmentController = startEnrollmentRender(
+            customerSession = editTextCustomerSession.text.toString(),
+            countryCode = editTextCountryCode.text.toString().uppercase(),
+            coroutineScope = lifecycleScope,
+            listener = this
+        )
+    }
+
+    // YunoEnrollmentRenderListener implementation
+
+    /**
+     * Receives the fragment to display in the UI container.
+     * @param fragment The fragment containing the enrollment form
+     * @param needSubmit Indicates if a custom submit button should be shown
+     */
+    override fun showView(fragment: Fragment, needSubmit: Boolean) {
+        // Replace the fragment in the container
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.enrollment_fragment_container, fragment)
+            .commit()
+
+        // Show/hide submit button based on needSubmit
+        needsSubmit = needSubmit
+        buttonSubmit.isVisible = needSubmit
+
+        Log.d("EnrollmentRender", "Fragment loaded, needSubmit: $needSubmit")
+    }
+
+    /**
+     * Receives the final enrollment status.
+     * @param resultCode Result code from the enrollment process
+     * @param paymentStatus The final enrollment status (SUCCEEDED, FAIL, etc.)
+     */
+    override fun returnStatus(resultCode: Int, paymentStatus: String) {
+        Log.d("EnrollmentRender", "Enrollment Status: $paymentStatus, Result Code: $resultCode")
+
+        // Handle the enrollment result
+        when (paymentStatus) {
+            "SUCCEEDED" -> {
+                Log.i("EnrollmentRender", "Enrollment succeeded!")
+                
+                // Remove the fragment
+                clearEnrollmentFragment()
+                
+                // Show success toast
+                Toast.makeText(this, "Payment method enrolled successfully!", Toast.LENGTH_LONG).show()
+                
+                // Close activity after a delay
+                Handler(Looper.getMainLooper()).postDelayed({
+                    finish()
+                }, 2000)
+            }
+
+            "FAIL" -> {
+                Log.e("EnrollmentRender", "Enrollment failed")
+                
+                // Remove the fragment
+                clearEnrollmentFragment()
+                
+                // Show error toast
+                Toast.makeText(this, "Enrollment failed. Please try again.", Toast.LENGTH_LONG).show()
+                
+                // Re-enable start button for retry
+                buttonStartEnrollment.isEnabled = true
+            }
+
+            "CANCELED" -> {
+                Log.w("EnrollmentRender", "Enrollment canceled by user")
+                
+                // Remove the fragment
+                clearEnrollmentFragment()
+                
+                // Show canceled toast
+                Toast.makeText(this, "Enrollment canceled", Toast.LENGTH_SHORT).show()
+                
+                // Close activity
+                finish()
+            }
+
+            else -> {
+                Log.w("EnrollmentRender", "Enrollment status: $paymentStatus")
+                
+                // Remove the fragment for any other status
+                clearEnrollmentFragment()
+                
+                // Re-enable start button
+                buttonStartEnrollment.isEnabled = true
+            }
+        }
+    }
+    
+    /**
+     * Clears the enrollment fragment from the container
+     */
+    private fun clearEnrollmentFragment() {
+        supportFragmentManager.findFragmentById(R.id.enrollment_fragment_container)?.let { fragment ->
+            supportFragmentManager.beginTransaction()
+                .remove(fragment)
+                .commit()
+        }
+        
+        // Hide submit button
+        buttonSubmit.visibility = View.GONE
+        needsSubmit = false
+    }
+
+    /**
+     * Receives loading state changes.
+     * @param isLoading True if the SDK is processing, false otherwise
+     */
+    override fun loadingListener(isLoading: Boolean) {
+        // Show/hide progress bar
+        progressBar.isVisible = isLoading
+
+        // Disable/enable submit button during loading
+        if (needsSubmit) {
+            buttonSubmit.isEnabled = !isLoading
+        }
+
+        Log.d("EnrollmentRender", "Loading state: $isLoading")
+    }
+}

--- a/app/src/main/java/com/yuno/payments/example/features/payment/activities/PaymentRenderActivity.kt
+++ b/app/src/main/java/com/yuno/payments/example/features/payment/activities/PaymentRenderActivity.kt
@@ -1,0 +1,338 @@
+package com.yuno.payments.example.features.payment.activities
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.View.GONE
+import android.view.View.VISIBLE
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.yuno.payments.example.BuildConfig
+import com.yuno.payments.example.R
+import com.yuno.payments.example.ui.views.CustomEditText
+import com.yuno.payments.features.payment.models.OneTimeTokenModel
+import com.yuno.presentation.core.components.PaymentSelected
+import com.yuno.sdk.payments.render.YunoPaymentFragmentController
+import com.yuno.sdk.payments.render.YunoPaymentRenderListener
+import com.yuno.sdk.payments.render.startPaymentRender
+import com.yuno.sdk.payments.startCheckout
+import com.yuno.sdk.payments.updateCheckoutSession
+
+class PaymentRenderActivity : AppCompatActivity(), YunoPaymentRenderListener {
+
+    private lateinit var fragmentController: YunoPaymentFragmentController
+
+    private lateinit var editTextCheckoutSession: CustomEditText
+    private lateinit var editTextCountryCode: CustomEditText
+    private lateinit var editTextPaymentMethod: CustomEditText
+    private lateinit var buttonStartPayment: Button
+    private lateinit var buttonSubmitPayment: Button
+    private lateinit var buttonContinuePayment: Button
+    private lateinit var textViewOtt: TextView
+    private lateinit var progressBar: ProgressBar
+    private lateinit var fragmentContainer: FrameLayout
+    private lateinit var configurationContainer: LinearLayout
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_payment_render)
+
+        // IMPORTANT: startCheckout() must be called in onCreate() before using any payment render functions.
+        // This initializes the payment flow and injects necessary dependencies for the SDK to work properly.
+        // Without this call, you'll get "Object not injected" errors when calling startPaymentRender().
+        startCheckout()
+
+        initViews()
+        initListeners()
+    }
+
+    private fun initViews() {
+        editTextCheckoutSession = findViewById(R.id.editText_checkout_session)
+        editTextCountryCode = findViewById(R.id.editText_country_code)
+        editTextPaymentMethod = findViewById(R.id.editText_payment_method)
+        buttonStartPayment = findViewById(R.id.button_start_payment)
+        buttonSubmitPayment = findViewById(R.id.button_submit_payment)
+        buttonContinuePayment = findViewById(R.id.button_continue_payment)
+        textViewOtt = findViewById(R.id.textView_ott)
+        progressBar = findViewById(R.id.progress_bar)
+        fragmentContainer = findViewById(R.id.payment_fragment_container)
+        configurationContainer = findViewById(R.id.linearLayout_configuration)
+
+        // Pre-fill with test data
+        editTextCheckoutSession.setText(BuildConfig.YUNO_TEST_CHECKOUT_SESSION)
+        editTextCountryCode.setText(BuildConfig.YUNO_TEST_COUNTRY_CODE)
+        editTextPaymentMethod.setText("CARD")
+
+        // Hide submit button initially (shown when form is loaded)
+        buttonSubmitPayment.visibility = GONE
+        buttonContinuePayment.visibility = GONE
+        textViewOtt.visibility = GONE
+    }
+
+    private fun initListeners() {
+        // Button to start the payment render flow
+        buttonStartPayment.setOnClickListener {
+            if (editTextCheckoutSession.isValid &&
+                editTextCountryCode.isValid &&
+                editTextPaymentMethod.isValid
+            ) {
+                startPaymentRenderFlow()
+            }
+        }
+
+        // Merchant's custom submit button
+        buttonSubmitPayment.setOnClickListener {
+            if (::fragmentController.isInitialized) {
+                fragmentController.submitForm()
+            }
+        }
+
+        // Continue payment button (after creating payment in backend)
+        buttonContinuePayment.setOnClickListener {
+            if (::fragmentController.isInitialized) {
+                // Hide the OTT and continue button
+                textViewOtt.visibility = GONE
+                buttonContinuePayment.visibility = GONE
+
+                // Continue with the payment flow (3DS, redirects, etc.)
+                fragmentController.continuePayment()
+            }
+        }
+
+        // Click on OTT TextView to copy to clipboard
+        textViewOtt.setOnClickListener {
+            val ottText = textViewOtt.text.toString()
+            // Extract just the token part (remove "One-Time Token: " prefix)
+            val token = ottText.substringAfter("One-Time Token: ")
+            
+            // Copy to clipboard
+            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            val clip = ClipData.newPlainText("One-Time Token", token)
+            clipboard.setPrimaryClip(clip)
+            
+            // Show feedback
+            Toast.makeText(this, "OTT copied to clipboard!", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun startPaymentRenderFlow() {
+
+
+        // IMPORTANT: Update the checkout session and country before starting the payment render
+        // This configures the SDK with the session and country that will be used for the payment
+        updateCheckoutSession(
+            checkoutSession = editTextCheckoutSession.text.toString(),
+            countryCode = editTextCountryCode.text.toString().uppercase()
+        )
+
+        // Start the payment render mode
+        // This function displays the payment form fragment in the UI
+        // Note: startCheckout() must have been called in onCreate() before this
+        fragmentController = startPaymentRender(
+            checkoutSession = editTextCheckoutSession.text.toString(),
+            countryCode = editTextCountryCode.text.toString().uppercase(),
+            coroutineScope = lifecycleScope,
+            paymentSelected = PaymentSelected(
+                vaultedToken = null,
+                paymentMethodType = editTextPaymentMethod.text.toString().uppercase()
+            ),
+            listener = this
+        )
+    }
+
+    // YunoPaymentRenderListener implementation
+
+    /**
+     * Receives the fragment to display in the UI container.
+     * @param fragment The fragment containing the payment form
+     */
+    override fun showView(fragment: Fragment) {
+        // Replace the fragment in the container
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.payment_fragment_container, fragment)
+            .commit()
+
+        // Hide configuration container (inputs and start button)
+        configurationContainer.visibility = GONE
+
+        // Show merchant's submit button below the form
+        buttonSubmitPayment.visibility = VISIBLE
+        buttonSubmitPayment.isEnabled = true
+
+        Log.d(
+            "PaymentRender",
+            "Payment fragment loaded, configuration hidden, merchant submit button visible"
+        )
+    }
+
+    /**
+     * Receives the one-time token when the customer completes the form.
+     * @param oneTimeToken The token needed to create the payment
+     * @param additionalData Additional information about the token
+     */
+    override fun returnOneTimeToken(oneTimeToken: String, additionalData: OneTimeTokenModel?) {
+        Log.d("PaymentRender", "One-time token received: $oneTimeToken")
+
+        // Remove the SDK form fragment
+        supportFragmentManager.findFragmentById(R.id.payment_fragment_container)?.let { fragment ->
+            supportFragmentManager.beginTransaction()
+                .remove(fragment)
+                .commit()
+        }
+
+        // Display the OTT in the TextView
+        textViewOtt.text = "One-Time Token: $oneTimeToken (tap to copy)"
+        textViewOtt.visibility = VISIBLE
+
+        // Show the continue payment button
+        buttonContinuePayment.visibility = VISIBLE
+        buttonContinuePayment.isEnabled = true
+
+        // Hide the submit button as it's no longer needed
+        buttonSubmitPayment.visibility = GONE
+
+        // Here the merchant would call their backend to create the payment with this OTT
+        // For this example, we're showing the OTT and letting the user manually continue
+        Toast.makeText(
+            this,
+            "OTT received! SDK form removed. Create payment in backend, then click Continue",
+            Toast.LENGTH_LONG
+        ).show()
+    }
+
+    /**
+     * Receives the final payment status.
+     * @param resultCode Result code from the payment process
+     * @param paymentStatus The final payment status (SUCCEEDED, FAIL, etc.)
+     * @param paymentSubStatus Additional detail about the payment status
+     */
+    override fun returnStatus(resultCode: Int, paymentStatus: String, paymentSubStatus: String?) {
+        Log.d(
+            "PaymentRender",
+            "Payment Status: $paymentStatus, Sub Status: $paymentSubStatus, Result Code: $resultCode"
+        )
+
+        // Handle the payment result
+        when (paymentStatus) {
+            "SUCCEEDED" -> {
+                Log.i("PaymentRender", "Payment succeeded!")
+
+                // Remove the fragment
+                clearPaymentFragment()
+
+                // Show success toast
+                Toast.makeText(this, "Payment completed successfully!", Toast.LENGTH_LONG).show()
+
+                // Close activity after a delay
+                Handler(Looper.getMainLooper()).postDelayed({
+                    finish()
+                }, 2000)
+            }
+
+            "FAIL" -> {
+                Log.e("PaymentRender", "Payment failed")
+
+                // Remove the fragment
+                clearPaymentFragment()
+
+                // Show error toast
+                Toast.makeText(this, "Payment failed. Please try again.", Toast.LENGTH_LONG).show()
+
+                // Re-enable start button for retry
+                buttonStartPayment.isEnabled = true
+            }
+
+            "CANCELED" -> {
+                Log.w("PaymentRender", "Payment canceled by user")
+
+                // Remove the fragment
+                clearPaymentFragment()
+
+                // Show canceled toast
+                Toast.makeText(this, "Payment canceled", Toast.LENGTH_SHORT).show()
+
+                // Close activity
+                finish()
+            }
+
+            "PROCESSING" -> {
+                Log.i("PaymentRender", "Payment is being processed")
+
+                // Show processing toast
+                val message = if (paymentSubStatus != null) {
+                    "Payment is being processed - $paymentSubStatus"
+                } else {
+                    "Payment is being processed"
+                }
+                Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+            }
+
+            "REJECT" -> {
+                Log.w("PaymentRender", "Payment rejected")
+
+                // Remove the fragment
+                clearPaymentFragment()
+
+                // Show rejected toast
+                Toast.makeText(this, "Payment rejected", Toast.LENGTH_LONG).show()
+
+                // Re-enable start button for retry
+                buttonStartPayment.isEnabled = true
+            }
+
+            else -> {
+                Log.w("PaymentRender", "Payment status: $paymentStatus")
+
+                // Remove the fragment for any other status
+                clearPaymentFragment()
+
+                // Re-enable start button
+                buttonStartPayment.isEnabled = true
+            }
+        }
+    }
+
+    /**
+     * Receives loading state changes.
+     * @param isLoading True if the SDK is processing, false otherwise
+     */
+    override fun loadingListener(isLoading: Boolean) {
+        // Show/hide progress bar
+        progressBar.isVisible = isLoading
+
+        Log.d("PaymentRender", "Loading state: $isLoading")
+    }
+
+    /**
+     * Clears the payment fragment from the container and shows configuration fields again
+     */
+    private fun clearPaymentFragment() {
+        supportFragmentManager.findFragmentById(R.id.payment_fragment_container)?.let { fragment ->
+            supportFragmentManager.beginTransaction()
+                .remove(fragment)
+                .commit()
+        }
+
+        // Show configuration fields again for retry
+        configurationContainer.visibility = VISIBLE
+
+        // Hide merchant submit button
+        buttonSubmitPayment.visibility = GONE
+
+        // Hide OTT and continue button
+        textViewOtt.visibility = GONE
+        buttonContinuePayment.visibility = GONE
+    }
+}

--- a/app/src/main/java/com/yuno/payments/example/ui/HomeActivity.kt
+++ b/app/src/main/java/com/yuno/payments/example/ui/HomeActivity.kt
@@ -6,8 +6,10 @@ import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import com.yuno.payments.example.R
 import com.yuno.payments.example.features.enrollment.activities.EnrollmentLiteActivity
+import com.yuno.payments.example.features.enrollment.activities.EnrollmentRenderActivity
 import com.yuno.payments.example.features.payment.activities.CheckoutCompleteActivity
 import com.yuno.payments.example.features.payment.activities.CheckoutLiteActivity
+import com.yuno.payments.example.features.payment.activities.PaymentRenderActivity
 
 class HomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -21,10 +23,18 @@ class HomeActivity : AppCompatActivity() {
             startActivity(Intent(this, EnrollmentLiteActivity::class.java))
         }
 
+        findViewById<Button>(R.id.button_enrollment_render).setOnClickListener {
+            startActivity(Intent(this, EnrollmentRenderActivity::class.java))
+        }
+
         findViewById<Button>(R.id.button_payment_lite)
             .setOnClickListener {
                 startActivity(Intent(this, CheckoutLiteActivity::class.java))
             }
+
+        findViewById<Button>(R.id.button_payment_render).setOnClickListener {
+            startActivity(Intent(this, PaymentRenderActivity::class.java))
+        }
 
         findViewById<Button>(R.id.button_payment_complete)
             .setOnClickListener {

--- a/app/src/main/java/com/yuno/payments/example/ui/views/CustomEditText.kt
+++ b/app/src/main/java/com/yuno/payments/example/ui/views/CustomEditText.kt
@@ -57,15 +57,15 @@ class CustomEditText @JvmOverloads constructor(
     private fun setEditTextState(state: EditTextState) {
         when (state) {
             EditTextState.ERROR -> {
-                setBackgroundResource(com.yuno.payments.R.drawable.bg_edit_text)
+                setBackgroundResource(com.yuno.payments.example.R.drawable.edittext_stroke_black)
                 setCursorColor(this.context, com.yuno.payments.R.color.neutral_b)
             }
             EditTextState.FOCUS -> {
-                setBackgroundResource(com.yuno.payments.R.drawable.bg_edit_text)
+                setBackgroundResource(com.yuno.payments.example.R.drawable.edittext_stroke_black)
                 setCursorColor(this.context, com.yuno.payments.R.color.primary_1)
             }
             EditTextState.NORMAL -> {
-                setBackgroundResource(com.yuno.payments.R.drawable.bg_edit_text)
+                setBackgroundResource(com.yuno.payments.example.R.drawable.edittext_stroke_black)
                 setCursorColor(this.context, com.yuno.payments.R.color.neutral_b)
             }
         }

--- a/app/src/main/res/drawable/edittext_stroke_black.xml
+++ b/app/src/main/res/drawable/edittext_stroke_black.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Estado enfocado -->
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <stroke
+                android:width="2dp"
+                android:color="#000000" />
+            <corners android:radius="4dp" />
+            <padding
+                android:bottom="12dp"
+                android:left="12dp"
+                android:right="12dp"
+                android:top="12dp" />
+        </shape>
+    </item>
+    
+    <!-- Estado normal -->
+    <item>
+        <shape android:shape="rectangle">
+            <stroke
+                android:width="1dp"
+                android:color="#000000" />
+            <corners android:radius="4dp" />
+            <padding
+                android:bottom="12dp"
+                android:left="12dp"
+                android:right="12dp"
+                android:top="12dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/activity_enrollment_render.xml
+++ b/app/src/main/res/layout/activity_enrollment_render.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:context=".features.enrollment.activities.EnrollmentRenderActivity">
+
+    <TextView
+        android:id="@+id/textView_title"
+        style="@style/TextH2.NeutralB"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Enrollment Render Mode"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.yuno.payments.example.ui.views.CustomEditText
+        android:id="@+id/editText_customer_session"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:hint="Customer Session"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/textView_title" />
+
+    <com.yuno.payments.example.ui.views.CustomEditText
+        android:id="@+id/editText_country_code"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:hint="Country Code"
+        android:maxLength="2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/editText_customer_session" />
+
+    <Button
+        android:id="@+id/button_start_enrollment"
+        style="@style/Button.Normal.NeutralB"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Start Enrollment"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/editText_country_code" />
+
+    <!-- Container for the enrollment fragment -->
+    <FrameLayout
+        android:id="@+id/enrollment_fragment_container"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="24dp"
+        app:layout_constraintBottom_toTopOf="@id/button_submit"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button_start_enrollment" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/enrollment_fragment_container"
+        app:layout_constraintEnd_toEndOf="@id/enrollment_fragment_container"
+        app:layout_constraintStart_toStartOf="@id/enrollment_fragment_container"
+        app:layout_constraintTop_toTopOf="@id/enrollment_fragment_container"
+        tools:visibility="visible" />
+
+    <Button
+        android:id="@+id/button_submit"
+        style="@style/Button.Normal.NeutralB"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="Submit Enrollment"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="visible" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -40,6 +40,15 @@
             android:text="Start Enrollment Lite"
             android:textAllCaps="false" />
 
+        <Button
+            android:id="@+id/button_enrollment_render"
+            style="@style/Button.Normal.NeutralB"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/yuno_spacing_standard"
+            android:text="Start Enrollment Render"
+            android:textAllCaps="false" />
+
         <TextView
             android:id="@+id/textView_title_payment"
             style="@style/TextH2.NeutralB"
@@ -55,6 +64,15 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/yuno_spacing_standard"
             android:text="Start Payment Lite"
+            android:textAllCaps="false" />
+
+        <Button
+            android:id="@+id/button_payment_render"
+            style="@style/Button.Normal.NeutralB"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/yuno_spacing_standard"
+            android:text="Start Payment Render"
             android:textAllCaps="false" />
 
         <Button

--- a/app/src/main/res/layout/activity_payment_render.xml
+++ b/app/src/main/res/layout/activity_payment_render.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <!-- Title -->
+        <TextView
+            android:id="@+id/textView_title"
+            style="@style/TextH2.NeutralB"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Payment Render Mode"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <!-- Configuration Container (can be hidden when form is shown) -->
+        <LinearLayout
+            android:id="@+id/linearLayout_configuration"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textView_title">
+
+            <!-- Checkout Session Input -->
+            <com.yuno.payments.example.ui.views.CustomEditText
+                android:id="@+id/editText_checkout_session"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Checkout Session"
+                android:inputType="text" />
+
+            <!-- Country Code Input -->
+            <com.yuno.payments.example.ui.views.CustomEditText
+                android:id="@+id/editText_country_code"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:hint="Country Code"
+                android:inputType="text" />
+
+            <!-- Payment Method Type Input -->
+            <com.yuno.payments.example.ui.views.CustomEditText
+                android:id="@+id/editText_payment_method"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:hint="Payment Method Type"
+                android:inputType="textCapCharacters" />
+
+            <!-- Start Payment Button -->
+            <Button
+                android:id="@+id/button_start_payment"
+                style="@style/Button.Normal.NeutralB"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="Start Payment"
+                android:textAllCaps="false" />
+
+        </LinearLayout>
+
+        <!-- Fragment Container for Yuno Payment Form -->
+        <FrameLayout
+            android:id="@+id/payment_fragment_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:minHeight="200dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/linearLayout_configuration" />
+
+        <!-- Submit Payment Button (Merchant custom button, shown below SDK form) -->
+        <Button
+            android:id="@+id/button_submit_payment"
+            style="@style/Button.Normal.Green"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Submit Payment (Merchant Button)"
+            android:textAllCaps="false"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/payment_fragment_container"
+            tools:visibility="visible" />
+
+        <!-- OTT Display (shown after form submission, clickable to copy) -->
+        <TextView
+            android:id="@+id/textView_ott"
+            style="@style/TextBody.NeutralB"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:background="@android:color/darker_gray"
+            android:padding="12dp"
+            android:text="One-Time Token: "
+            android:textColor="@android:color/white"
+            android:clickable="true"
+            android:focusable="true"
+            android:foreground="?attr/selectableItemBackground"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/button_submit_payment"
+            tools:text="One-Time Token: abc123xyz (tap to copy)"
+            tools:visibility="visible" />
+
+        <!-- Continue Payment Button -->
+        <Button
+            android:id="@+id/button_continue_payment"
+            style="@style/Button.Normal.NeutralB"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Continue Payment"
+            android:textAllCaps="false"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textView_ott"
+            tools:visibility="visible" />
+
+        <!-- Progress Bar -->
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@id/payment_fragment_container"
+            app:layout_constraintEnd_toEndOf="@id/payment_fragment_container"
+            app:layout_constraintStart_toStartOf="@id/payment_fragment_container"
+            app:layout_constraintTop_toTopOf="@id/payment_fragment_container"
+            tools:visibility="visible" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/app/src/main/res/values/button_styles.xml
+++ b/app/src/main/res/values/button_styles.xml
@@ -35,12 +35,12 @@
 
     <style name="Button.Normal.NeutralB">
         <item name="android:background">@drawable/button_neutralb_style</item>
-        <item name="android:textColor">@color/button_text_color</item>
+        <item name="android:textColor">@android:color/white</item>
     </style>
 
     <style name="Button.Small.NeutralB" parent="Button.Small">
         <item name="android:background">@drawable/button_neutralb_style</item>
-        <item name="android:textColor">@color/button_text_color</item>
+        <item name="android:textColor">@android:color/white</item>
     </style>
 
 </resources>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces fragment-based Render Mode examples and documentation for both Enrollment and Payments.
> 
> - README: Adds advanced integration guides for `startEnrollmentRender` and `startPaymentRender`, listener contracts, flow steps, layout examples, and best practices
> - Example app: New `EnrollmentRenderActivity` and `PaymentRenderActivity` implementing render flows (submit via controller, OTT handling, `continuePayment`, status and loading callbacks)
> - Manifest/Home: Registers new activities and adds Home buttons to launch them
> - UI: Adds `activity_enrollment_render.xml`, `activity_payment_render.xml`, and `edittext_stroke_black.xml`; updates `CustomEditText` to use local drawable; sets NeutralB button text color to white
> - App init: Updates `CustomApplication` to use `YunoConfig` with `CardFormType.ONE_STEP` and `saveCardEnabled=false`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 990c514622170cbd2e7e08924752f5048d3f2339. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->