### PR TITLE
Project | Update SDK Version to 2.13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.13.3-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.13.4-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.13.3'
+    implementation 'com.yuno.payments:android-sdk:2.13.4'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Summary
- Bump Yuno Android SDK dependency from 2.13.3 to 2.13.4 in `app/build.gradle`
- Update Yuno SDK badge in `README.md` to 2.13.4

## Test plan
- [ ] Gradle sync succeeds
- [ ] App builds and runs
- [ ] Checkout, enrollment, and render flows work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump and documentation badge update; primary risk is potential behavioral changes introduced by the upstream SDK version.
> 
> **Overview**
> Updates the example app to use **Yuno Android SDK `2.13.4`** by bumping the Gradle dependency from `2.13.3` to `2.13.4`.
> 
> Keeps documentation in sync by updating the `README.md` Yuno SDK version badge to `2.13.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5101d8306b48d354b5f6124c64869996162976a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->