### PR TITLE
Project | Update SDK Version to 2.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.15.0-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.15.1-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.15.0'
+    implementation 'com.yuno.payments:android-sdk:2.15.1'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Summary
- Bump Yuno Android SDK from 2.15.0 to 2.15.1 in `app/build.gradle`
- Update SDK badge in `README.md` to match

## Test plan
- [ ] `./gradlew assembleDebug` succeeds
- [ ] App launches and all 5 demo flows run against the new SDK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-version dependency bump with no application code changes; risk is limited to SDK 2.15.1 behavior in existing demo flows.
> 
> **Overview**
> Updates the example app to **Yuno Android SDK 2.15.1** (from 2.15.0).
> 
> The dependency in `app/build.gradle` is bumped to `com.yuno.payments:android-sdk:2.15.1`, and the README badge is updated so documented version matches the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81940de3ad6fc2da49c19f372463663cb30011fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->