### PR TITLE
Project | Update SDK Version to 2.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.15.1-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.16.0-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.15.1'
+    implementation 'com.yuno.payments:android-sdk:2.16.0'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Summary

Update the Yuno Android SDK dependency from **2.15.1 → 2.16.0**.

## Changes
- `app/build.gradle` — `com.yuno.payments:android-sdk:2.16.0`
- `README.md` — version badge bumped to 2.16.0

## Release Notes

**ADDED — Native 3DS via the optional Yuno3DSNetcetera module**

A new optional companion module that runs native 3DS challenges and device data collection inside your app. Add the dependency alongside the core SDK and it gets picked up automatically — no extra wiring. Published as **Yuno3DSNetcetera 1.0.1** on JFrog and compatible with the core SDK starting at **2.16.0**.

## Verification
- `./gradlew assembleDebug` → **BUILD SUCCESSFUL** (dependency 2.16.0 resolves correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bump only in the example app with no runtime or integration logic changes.
> 
> **Overview**
> Bumps the example app’s **Yuno Android SDK** dependency from **2.15.1** to **2.16.0** in `app/build.gradle` and updates the README version badge to match.
> 
> No application or integration code changes—this is a dependency-only upgrade. **2.16.0** is the baseline for the optional **Yuno3DSNetcetera** module (native 3DS); this PR does not add that module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57bb5f71f9afa412f784181efecf88872f2fcb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->