### PR TITLE
Project | Update SDK Version to 2.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.16.0-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.16.1-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.16.0'
+    implementation 'com.yuno.payments:android-sdk:2.16.1'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Summary

Update the Yuno Android SDK dependency from **2.16.0 → 2.16.1**.

## Changes
- `app/build.gradle` — `com.yuno.payments:android-sdk:2.16.1`
- `README.md` — version badge bumped to 2.16.1

## Release Notes

**FIXED — Back gesture/button now cancels the 3DS challenge in render mode**

In render mode, pressing back (button or gesture) during a 3D Secure challenge now closes it and returns **CANCELED_BY_USER** to the merchant, matching iOS. Previously the back press was ignored and the payment hung until the server-side challenge timeout. Back now always cancels instead of walking the WebView history (which could leave a blank screen).

## Verification
- `./gradlew assembleDebug` → **BUILD SUCCESSFUL** (dependency 2.16.1 resolves correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation version bump only; no application logic changes in this repo.
> 
> **Overview**
> Bumps the example app to **Yuno Android SDK 2.16.1** by updating `com.yuno.payments:android-sdk` in `app/build.gradle` and the README version badge.
> 
> No app code changes—integrators pulling this version get the SDK fix where **back during a 3DS challenge in render mode** cancels the flow and reports **CANCELED_BY_USER** instead of ignoring back or hanging until timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed961853a002c77c5fbccd9d8509e75cf185fd2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->