### PR TITLE
Project | Update SDK Version to 2.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ An Android example app that demonstrates the integration of the **Yuno Payments 
   - [Enroll a new payment method](#enroll-a-new-payment-method)
   - [Enrollment Render Mode (Advanced)](#enrollment-render-mode-advanced-integration)
   - [Checkout](#checkout)
+  - [Headless (Advanced)](#headless-advanced-integration)
   - [Payment Render Mode (Advanced)](#payment-render-mode-advanced-integration)
 
 ---
@@ -592,6 +593,107 @@ continuePayment(
 
 To show your own payment status screens, you should send `false` in the `showPaymentStatus`
 parameter and then get the payment state by callback.
+
+### Headless (Advanced Integration)
+
+The Headless integration gives you full control over the payment UI. You render your own forms, the SDK tokenizes the card data into a One-Time Token (OTT), you create the payment in your backend, and the SDK resumes any pending action (such as a 3DS challenge) for you.
+
+#### Create the API client
+
+```kotlin
+val apiClient = Yuno.apiClientPayment(
+    checkoutSession = "checkout_session",
+    countryCode = "country_code_iso", //Optional - Default ""
+    context = context,
+)
+```
+
+#### Generate the One-Time Token
+
+Collect the card data with your own UI and pass it to `generateToken` to obtain the OTT.
+
+```kotlin
+suspend fun ApiClientPayment.generateToken(
+    collectedData: TokenCollectedData,
+    context: Context,
+): Map<String, Any?>
+```
+
+`TokenCollectedData` describes the data sent for tokenization:
+
+```kotlin
+data class TokenCollectedData(
+    val checkoutSession: String? = null,
+    val customerSession: String? = null,
+    val paymentMethod: PaymentMethod,
+)
+
+data class PaymentMethod(
+    val type: String, //Required - The payment method type (e.g., "CARD")
+    val vaultedToken: String? = null,
+    val card: CardData? = null,
+    val customer: Customer? = null,
+)
+```
+
+Call it from a coroutine. The returned map contains the OTT under the `token` key (or an `error` key on failure):
+
+```kotlin
+lifecycleScope.launch {
+    val result = apiClient.generateToken(tokenCollectedData, context)
+    val ott = result["token"] as? String
+    // Send the OTT to your backend to create the payment via POST /payments
+}
+```
+
+#### Continue the payment (if required)
+
+If the create_payment response returns `sdk_action_required = true` (for example, a 3DS challenge), call `continueCardPayment`. The SDK executes the pending action internally — including rendering the 3DS challenge — waits for the result, and delivers the final payment state to your callback.
+
+```kotlin
+fun ApiClientPayment.continueCardPayment(
+    activity: ComponentActivity,
+    showPaymentStatus: Boolean = true, //Optional - Default true
+    callbackPaymentState: ((String?, String?) -> Unit)? = null, //Optional - Default null
+)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `activity` | The `ComponentActivity` the SDK uses to present the pending action. |
+| `showPaymentStatus` | A boolean that specifies whether the payment status should be displayed within the Yuno interface. Send `false` to use your own status UI and rely only on the callback. Default is `true`. |
+| `callbackPaymentState` | A function that returns the final payment state and sub-state once the flow completes. Uses the same payment states described in the [Callback Payment State](#callback-payment-state) section. |
+
+```kotlin
+Yuno.apiClientPayment(
+    checkoutSession = "checkout_session",
+    countryCode = "country_code_iso",
+    context = this,
+).continueCardPayment(
+    activity = this,
+    showPaymentStatus = false,
+) { paymentState, paymentSubState ->
+    when (paymentState) {
+        "SUCCEEDED" -> { }
+        "PROCESSING" -> { }
+        "REJECT", "FAIL" -> { }
+        "CANCELED_BY_USER" -> { }
+        "INTERNAL_ERROR" -> { }
+        else -> { }
+    }
+}
+```
+
+> **Note:** `continueCardPayment` supports `CARD` payments only.
+
+#### Headless Flow Steps
+
+1. **Create the API client**: call `Yuno.apiClientPayment()` with the checkout session
+2. **Collect card data**: render your own payment form
+3. **Generate the OTT**: call `generateToken()` and read the `token` key
+4. **Create payment**: call your backend with the OTT via `POST /payments`
+5. **Continue**: if `sdk_action_required` is `true`, call `continueCardPayment()`
+6. **Complete**: handle the final state in `callbackPaymentState`
 
 ### Payment Render Mode (Advanced Integration)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An Android example app that demonstrates the integration of the **Yuno Payments 
   - [Enroll a new payment method](#enroll-a-new-payment-method)
   - [Enrollment Render Mode (Advanced)](#enrollment-render-mode-advanced-integration)
   - [Checkout](#checkout)
-  - [Headless (Advanced)](#headless-advanced-integration)
+  - [Headless](#headless)
   - [Payment Render Mode (Advanced)](#payment-render-mode-advanced-integration)
 
 ---
@@ -594,7 +594,7 @@ continuePayment(
 To show your own payment status screens, you should send `false` in the `showPaymentStatus`
 parameter and then get the payment state by callback.
 
-### Headless (Advanced Integration)
+### Headless
 
 The Headless integration gives you full control over the payment UI. You render your own forms, the SDK tokenizes the card data into a One-Time Token (OTT), you create the payment in your backend, and the SDK resumes any pending action (such as a 3DS challenge) for you.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.16.1-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.17.0-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.16.1'
+    implementation 'com.yuno.payments:android-sdk:2.17.0'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Summary
- Bump Yuno Android SDK dependency from `2.16.1` to `2.17.0`.

## Changes
- `app/build.gradle`: `com.yuno.payments:android-sdk:2.16.1` → `2.17.0`
- `README.md`: SDK badge `2.16.1` → `2.17.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bump and documentation only; no application code changes in the diff.
> 
> **Overview**
> Updates the example app to **Yuno Android SDK 2.17.0** (`app/build.gradle` and the README version badge).
> 
> The README also gains a new **Headless** section (plus TOC link) that documents the custom-UI payment path: `Yuno.apiClientPayment()`, coroutine-based `generateToken()` with `TokenCollectedData`, backend `POST /payments`, and `continueCardPayment()` when `sdk_action_required` is true (e.g. 3DS), including a six-step flow summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b8a27c1dac14ba0cee5322fea06033ffbd39f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->