### PR TITLE
Project | Update SDK Version to 2.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.17.0-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.17.1-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.17.0'
+    implementation 'com.yuno.payments:android-sdk:2.17.1'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Summary
Bumps the Yuno Android SDK from **2.17.0 → 2.17.1**.

- \`app/build.gradle\` — SDK dependency
- \`README.md\` — version badge

## SDK 2.17.1 — Payments
**FIXED:** card payments with an installment plan now return the one-time token. The token endpoint response was being rejected while parsing because the installment amount is delivered as a money object (currency + value); the SDK now reads it correctly and surfaces the token through \`callbackOTT\` / \`callBackTokenWithInformation\` as before. Other payment methods were not affected.

Tag: \`V-2.17.1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation version-only changes with no app logic modified.
> 
> **Overview**
> Updates the example app to **Yuno Android SDK 2.17.1** by changing the `com.yuno.payments:android-sdk` dependency in `app/build.gradle` and the README version badge.
> 
> This is a patch bump from 2.17.0; the SDK fix in 2.17.1 addresses installment card payments where the token response failed to parse when installment amount was a money object—tokens should again flow through `callbackOTT` / `callBackTokenWithInformation` for that flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd262a982e7dc14e913ae6ae74a7f050e1c2f17b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->