### PR TITLE
Project | Update SDK Version to 2.17.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.17.2-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.17.3-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.17.2'
+    implementation 'com.yuno.payments:android-sdk:2.17.3'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Resumen
Bump del SDK de Yuno a **2.17.3** (release del 30 de junio de 2026), siguiendo el patrón de los releases anteriores.

## Cambios
- \`README.md\` — badge de Yuno SDK \`2.17.2\` → \`2.17.3\`
- \`app/build.gradle\` — \`com.yuno.payments:android-sdk\` \`2.17.2\` → \`2.17.3\`

Tag anotado: \`V-2.17.3\`

## Changelog 2.17.3 — Payments
**FIXED:** La app anfitriona ya no falla cuando no se puede abrir el deeplink de retorno de un pago. Los WebViews ya no fallan al intentar abrir un deeplink si la app destino no está instalada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation version bump only; payment deeplink handling improvements live in the external SDK artifact.
> 
> **Overview**
> Bumps the example app to **Yuno Payments Android SDK 2.17.3** by updating the Gradle dependency in `app/build.gradle` and the README version badge.
> 
> This is a version-only change; no app source or integration code is modified. **2.17.3** fixes host-app crashes when payment return deeplinks cannot be opened and WebView failures when the target app for a deeplink is not installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b34af6331c8176fa53d0d0c065d9bd528afb35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->