### PR TITLE
Project | Update SDK Version to 2.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.17.3-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.18.0-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.17.3'
+    implementation 'com.yuno.payments:android-sdk:2.18.0'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Resumen
Bump del SDK de Yuno a **2.18.0**, siguiendo el patrón de los releases anteriores.

## Cambios
- `README.md` — badge de Yuno SDK `2.17.3` → `2.18.0`
- `app/build.gradle` — `com.yuno.payments:android-sdk` `2.17.3` → `2.18.0`

Tag: `V-2.18.0`

## Changelog 2.18.0 — Payments
**FIXED:** El toggle de tipo de tarjeta (crédito/débito) ya no se muestra en el formulario de tarjeta desplegado (lista de métodos de pago) cuando el comercio tiene `credit_card_only_processing` habilitado. El flag no se propagaba a ese call site y el toggle siempre aparecía para tarjetas brasileñas; ahora se resuelve directamente desde los settings del SDK, así que todos los formularios lo respetan.

**CHANGED:** El dropdown de cuotas ahora muestra el valor por cuota y el monto total (ej. `2x of R$ 500,31 - Total R$ 1.000,61`), alineado con el Web SDK. Si no hay total disponible cae al formato anterior por cuota, y sin monto muestra solo el número de cuotas. ([CORECM-17537](https://yunopayments.atlassian.net/browse/CORECM-17537))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORECM-17537]: https://yunopayments.atlassian.net/browse/CORECM-17537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ