### PR TITLE
Project | Update SDK Version to 2.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.18.0-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.19.0-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.18.0'
+    implementation 'com.yuno.payments:android-sdk:2.19.0'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Summary
Bump Yuno Android SDK dependency from `2.18.0` to `2.19.0`.

## Changes
- `app/build.gradle` — `com.yuno.payments:android-sdk:2.18.0` → `2.19.0`
- `README.md` — Yuno SDK badge `2.18.0` → `2.19.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)