### PR TITLE
Project | Update SDK Version to 2.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.19.0-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.20.0-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.19.0'
+    implementation 'com.yuno.payments:android-sdk:2.20.0'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Summary
Bump Yuno Android SDK dependency from `2.19.0` to `2.20.0`.

## Changes
- `app/build.gradle` — `com.yuno.payments:android-sdk:2.19.0` → `2.20.0`
- `README.md` — Yuno SDK badge `2.19.0` → `2.20.0`

## Release highlights (2.20.0)
- **ADDED:** optional `onInstallmentSelected` callback in `startCheckout` (Web parity) — fires on every installment selection/change in the card form, including default pre-selection and BIN-change recalculations; fires with `null` when installments become unavailable. Fully backwards compatible. (CORECM-18470)

## Verification
- `./gradlew assembleDebug` — BUILD SUCCESSFUL (2.20.0 resolves from Maven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency and README badge update with no app logic changes; risk is limited to whatever behavior changes ship in SDK 2.20.0.
> 
> **Overview**
> Bumps the example app’s **Yuno Payments Android SDK** dependency from **2.19.0** to **2.20.0** and updates the README badge to match.
> 
> There are no integration or source changes in this repo—only the Maven coordinate in `app/build.gradle` and documentation branding. Consumers pulling **2.20.0** get the SDK’s new optional `onInstallmentSelected` callback on `startCheckout` (installment selection changes in the card form); this sample does not wire that callback yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626ace804505eeefc513dd7477fadddf772db8e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->