### PR TITLE
Project | Update SDK Version to 2.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-1.5.4-green?logo=jetpackcompose)
 ![Min SDK](https://img.shields.io/badge/Min%20SDK-21-yellow)
 ![Target SDK](https://img.shields.io/badge/Target%20SDK-35-brightgreen)
-![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.20.1-purple)
+![Yuno SDK](https://img.shields.io/badge/Yuno%20SDK-2.21.0-purple)
 
 An Android example app that demonstrates the integration of the **Yuno Payments SDK**, including enrollment, checkout, payment flows, and render mode (advanced integration).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
 
-    implementation 'com.yuno.payments:android-sdk:2.20.1'
+    implementation 'com.yuno.payments:android-sdk:2.21.0'
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
 }


### PR DESCRIPTION
## Summary
Bump Yuno Android SDK dependency from `2.20.1` to `2.21.0`.

## Changes
- `app/build.gradle` — `com.yuno.payments:android-sdk:2.20.1` → `2.21.0`
- `README.md` — Yuno SDK badge `2.20.1` → `2.21.0`

## Release highlights (2.21.0)
- **NEW:** OTP auto-read via SMS (User Consent), address autofill, expanded payment methods in the list, ACH account type selectors
- **IMPROVED:** RTL layouts, Powered-by-Yuno privacy tag
- **FIXED:** Android 7 timestamp crash, payment callback stability